### PR TITLE
Use DEV_API_URL env var for mobile config

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -23,7 +23,7 @@ This single command will:
 
 This will:
 - ✅ Auto-detect your local IP address
-- ✅ Update mobile app config automatically
+- ✅ Set `DEV_API_URL` environment variable for the app
 - ✅ Install dependencies if needed
 - ✅ Start Expo development server
 - ✅ Show QR code for your phone
@@ -74,7 +74,7 @@ sudo apt-get install redis-server
 **"Network request failed" on phone**
 - Make sure both devices are on the same WiFi
 - Check that `./start_servers.sh` is running
-- Verify the IP address in `mobile/config.ts` matches your computer's IP
+- Ensure `DEV_API_URL` points to your computer's IP (set automatically by `start_mobile.sh`)
 
 **"Virtual environment not found"**
 ```bash

--- a/mobile/config.ts
+++ b/mobile/config.ts
@@ -8,22 +8,23 @@
 import { Platform } from 'react-native';
 
 /**
- * ====================================================================================
- * !! IMPORTANT !! - SET YOUR DEVELOPMENT API URL HERE
- * ====================================================================================
+ * =============================================================================
+ * Development Configuration
+ * =============================================================================
  *
- * To connect the mobile app to your local backend server, you must replace the
- * placeholder IP address with your computer's local network IP address.
- *
- * How to find your local IP address:
- *   - On macOS: Go to System Settings > Network > Wi-Fi. Your IP address is listed there.
- *   - On Windows: Open Command Prompt and type `ipconfig`. Look for the "IPv4 Address".
- *
- * The IP address will likely look like `192.168.x.x` or `10.0.x.x`.
- *
- * ====================================================================================
+ * The development API URL is read from the `DEV_API_URL` environment variable.
+ * The `start_mobile.sh` script sets this automatically based on your computer's IP address.
  */
-const DEV_API_URL = 'http://172.16.0.169:8000/v1';
+/**
+ * Development API URL
+ *
+ * When running the app locally, the backend URL can be provided via the
+ * `DEV_API_URL` environment variable. The `start_mobile.sh` script sets this
+ * automatically based on your computer's IP address. If the variable is not
+ * set, we fall back to `http://localhost:8000/v1` which works when running in
+ * a web browser.
+ */
+const DEV_API_URL = process.env.DEV_API_URL || 'http://localhost:8000/v1';
 
 /**
  * For production builds, you would use your actual production API URL.

--- a/start_mobile.sh
+++ b/start_mobile.sh
@@ -14,7 +14,7 @@ NC='\033[0m' # No Color
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$PROJECT_ROOT/mobile"
-CONFIG_FILE="$MOBILE_DIR/config.ts"
+CONFIG_FILE="$MOBILE_DIR/config.ts"  # Deprecated: config is now via env var
 
 print_header() {
     echo -e "${BLUE}"
@@ -46,22 +46,14 @@ get_local_ip() {
     echo "$LOCAL_IP"
 }
 
-update_config() {
-    echo -e "${YELLOW}Updating mobile app configuration...${NC}"
-    
+set_dev_api_url() {
+    echo -e "${YELLOW}Configuring development API URL...${NC}"
+
     LOCAL_IP=$(get_local_ip)
-    echo -e "${GREEN}Detected local IP: $LOCAL_IP${NC}"
-    
-    # Update the config file with the detected IP
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS sed
-        sed -i '' "s|const DEV_API_URL = 'http://.*:8000/v1';|const DEV_API_URL = 'http://$LOCAL_IP:8000/v1';|" "$CONFIG_FILE"
-    else
-        # Linux sed
-        sed -i "s|const DEV_API_URL = 'http://.*:8000/v1';|const DEV_API_URL = 'http://$LOCAL_IP:8000/v1';|" "$CONFIG_FILE"
-    fi
-    
-    echo -e "${GREEN}Mobile app configured to use: http://$LOCAL_IP:8000/v1${NC}"
+    DEV_URL="http://$LOCAL_IP:8000/v1"
+    export DEV_API_URL="$DEV_URL"
+
+    echo -e "${GREEN}DEV_API_URL set to: $DEV_URL${NC}"
 }
 
 check_backend() {
@@ -131,7 +123,7 @@ show_instructions() {
     echo "📱 Mobile App Setup Complete!"
     echo "==========================================${NC}"
     echo -e "${GREEN}Backend API:${NC} http://$LOCAL_IP:8000"
-    echo -e "${GREEN}Mobile Config:${NC} Updated automatically"
+    echo -e "${GREEN}DEV_API_URL:${NC} $DEV_API_URL"
     echo ""
     echo -e "${YELLOW}To use the mobile app:${NC}"
     echo "1. Install 'Expo Go' on your phone from the App Store"
@@ -160,7 +152,7 @@ main() {
         exit 1
     fi
     
-    update_config
+    set_dev_api_url
     check_backend
     setup_mobile
     show_instructions


### PR DESCRIPTION
## Summary
- read `DEV_API_URL` in `mobile/config.ts` and fallback to localhost
- configure `start_mobile.sh` to export `DEV_API_URL` instead of editing the config file
- update quick start docs for new configuration

## Testing
- `pytest backend/parser/tests/ -v` *(fails: ImportError: pdfplumber is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c6965e2d88333b445e11d22423c9b