### PR TITLE
Remove dev endpoints and simplify backend logic

### DIFF
--- a/backend/aggregator/scraper.py
+++ b/backend/aggregator/scraper.py
@@ -9,7 +9,6 @@ import requests
 from typing import Dict, Any, Optional
 from dataclasses import dataclass
 from urllib.parse import urlparse
-import time
 import logging
 
 logger = logging.getLogger(__name__)
@@ -59,88 +58,34 @@ class JobScraper:
         logger.info(f"Starting job scraping for URL: {url}")
         
         try:
-            # Parse URL to determine scraping strategy
-            parsed_url = urlparse(url)
-            domain = parsed_url.netloc.lower()
-            
-            # Route to specific scraper based on domain
+            parsed = urlparse(url)
+            domain = parsed.netloc.lower()
+
             if 'linkedin.com' in domain:
-                return self._scrape_linkedin(url)
+                company = 'LinkedIn'
             elif 'indeed.com' in domain:
-                return self._scrape_indeed(url)
+                company = 'Indeed'
             elif 'glassdoor.com' in domain:
-                return self._scrape_glassdoor(url)
+                company = 'Glassdoor'
             else:
-                return self._scrape_generic(url)
+                company = domain.split('.')[0].title() if domain else 'Unknown'
+
+            return self._placeholder_posting(url, company)
                 
         except Exception as e:
             logger.error(f"Job scraping failed for URL: {url}, error: {str(e)}")
             raise
     
-    def _scrape_linkedin(self, url: str) -> JobPosting:
-        """Scrape LinkedIn job posting."""
-        # TODO: Implement LinkedIn-specific scraping
-        # For now, return mock data
-        time.sleep(2)  # Simulate processing time
-        
-        return JobPosting(
-            title="Software Engineer Intern",
-            company="LinkedIn",
-            location="San Francisco, CA",
-            description="Join our team as a software engineer intern and work on cutting-edge technology...",
-            requirements=["Python", "JavaScript", "React", "SQL"],
-            employment_type="Internship",
-            url=url
-        )
-    
-    def _scrape_indeed(self, url: str) -> JobPosting:
-        """Scrape Indeed job posting."""
-        # TODO: Implement Indeed-specific scraping
-        time.sleep(2)
-        
-        return JobPosting(
-            title="Data Science Intern",
-            company="Indeed",
-            location="Austin, TX",
-            description="Work with our data science team to analyze job market trends...",
-            requirements=["Python", "SQL", "Machine Learning", "Statistics"],
-            employment_type="Internship",
-            url=url
-        )
-    
-    def _scrape_glassdoor(self, url: str) -> JobPosting:
-        """Scrape Glassdoor job posting."""
-        # TODO: Implement Glassdoor-specific scraping
-        time.sleep(2)
-        
-        return JobPosting(
-            title="Product Manager Intern",
-            company="Glassdoor",
-            location="Mill Valley, CA",
-            description="Support product development and user research initiatives...",
-            requirements=["Product Management", "Analytics", "Communication"],
-            employment_type="Internship",
-            url=url
-        )
-    
-    def _scrape_generic(self, url: str) -> JobPosting:
-        """Generic scraping for unknown job boards."""
-        # TODO: Implement generic scraping using BeautifulSoup
-        time.sleep(3)
-        
-        # Extract domain for company name fallback
-        parsed_url = urlparse(url)
-        domain_parts = parsed_url.netloc.split('.')
-        company_guess = domain_parts[0] if domain_parts else "Unknown Company"
-        
+    def _placeholder_posting(self, url: str, company: str) -> JobPosting:
+        """Return a simple placeholder posting."""
         return JobPosting(
             title="Software Engineering Intern",
-            company=company_guess.title(),
+            company=company,
             location="Remote",
-            description="Exciting internship opportunity in software engineering...",
-            requirements=["Programming", "Problem Solving", "Teamwork"],
+            description="Demo job posting",
+            requirements=["Python"],
             employment_type="Internship",
-            url=url
+            url=url,
         )
 
 

--- a/backend/api/jobs.py
+++ b/backend/api/jobs.py
@@ -66,27 +66,11 @@ def parse_resume_job(self, upload_id: str, file_path: str, user_id: str) -> Dict
         # Import upload_records to update status
         from .routers.uploads import upload_records, parsed_data_store
         
-        # Fix file path - ensure we're looking from the project root
+        # Normalise path for local access
         if not os.path.isabs(file_path):
-            # Try multiple possible paths
-            possible_paths = [
-                file_path,  # Original path
-                os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), file_path),  # From project root
-                os.path.join("/Users/matthewdomingo/Documents/Personal/Project/ShipIt", file_path),  # Absolute project root
-            ]
-            
-            actual_file_path = None
-            for path in possible_paths:
-                if os.path.exists(path):
-                    actual_file_path = path
-                    break
-            
-            if actual_file_path:
-                file_path = actual_file_path
-                logger.info(f"Found file at: {file_path}")
-            else:
-                logger.error(f"File not found. Tried paths: {possible_paths}")
-                raise FileNotFoundError(f"Resume file not found: {file_path}")
+            file_path = os.path.abspath(file_path)
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Resume file not found: {file_path}")
         
         # Use the actual parser module to extract resume data
         resume_data = extract_resume_data_smart(file_path)
@@ -94,12 +78,6 @@ def parse_resume_job(self, upload_id: str, file_path: str, user_id: str) -> Dict
         # Convert to serializable format for storage
         parsed_data = resume_data.to_dict()
         
-        # --- DEBUG LOGGING START ---
-        logger.info("--- DETAILED PARSED DATA ---")
-        logger.info(f"PARSED EDUCATION: {parsed_data.get('education')}")
-        logger.info(f"PARSED EXPERIENCE: {parsed_data.get('experience')}")
-        logger.info("--- END DETAILED PARSED DATA ---")
-        # --- DEBUG LOGGING END ---
         
         # Store parsed data and update upload record status
         parsed_data_for_storage = {
@@ -109,27 +87,7 @@ def parse_resume_job(self, upload_id: str, file_path: str, user_id: str) -> Dict
             "education": parsed_data.get('education', []),
             "experience": parsed_data.get('experience', []),
             "skills": parsed_data.get('skills', []),
-            "additional_sections": parsed_data.get('additional_sections', {}),
-            "summary": {
-                "contact_fields_detected": sum([
-                    bool(parsed_data.get('contact', {}).get('name')),
-                    bool(parsed_data.get('contact', {}).get('email')),
-                    bool(parsed_data.get('contact', {}).get('phone')),
-                    bool(parsed_data.get('contact', {}).get('linkedin')),
-                    bool(parsed_data.get('contact', {}).get('github'))
-                ]),
-                "education_entries": len(parsed_data.get('education', [])),
-                "experience_entries": len(parsed_data.get('experience', [])),
-                "skills_count": len(parsed_data.get('skills', [])),
-                "additional_sections_count": len(parsed_data.get('additional_sections', {})),
-                "total_data_points": sum([
-                    bool(parsed_data.get('contact', {}).get('name')),
-                    bool(parsed_data.get('contact', {}).get('email')),
-                    bool(parsed_data.get('contact', {}).get('phone')),
-                    bool(parsed_data.get('contact', {}).get('linkedin')),
-                    bool(parsed_data.get('contact', {}).get('github'))
-                ]) + len(parsed_data.get('education', [])) + len(parsed_data.get('experience', [])) + len(parsed_data.get('skills', []))
-            }
+            "additional_sections": parsed_data.get('additional_sections', {})
         }
         
         # Store in Redis for shared access between Celery and API server


### PR DESCRIPTION
## Summary
- remove dev-only parse-now and debug APIs
- simplify file path normalization in Celery job
- trim verbose parsed data summary
- consolidate scraper placeholders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687698c2892883338191920bba51edfd